### PR TITLE
Include LXML dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 #This is a list of files to install, and where
 #(relative to the 'root' dir, where setup.py is)
@@ -13,6 +13,7 @@ setup(name = "ioc_writer",
     url = "http://www.github.com/mandiant/iocwriter_11/",
     packages = ['ioc_writer'],
     package_data = {'package' : files },
+    install_requires = ['lxml>=3.2.0'],
     #scripts = ["runner"],
     long_description = """API providing a limited CRUD for manipulating OpenIOC formatted Indicators of Compromise.""",
     #This next part it for the Cheese Shop, look a little down the page.


### PR DESCRIPTION
This will automatically install lxml when installing IOC writer. Also switch from using distutils to setuptools.

Also, would you be ok with putting this package on PyPI? I'm willing to help if you need it. This would make it easier to install (for example, with pip).
