### PR TITLE
Convert string to bytes for newline file write

### DIFF
--- a/examples/openioc_to_yara/openioc_to_yara.py
+++ b/examples/openioc_to_yara/openioc_to_yara.py
@@ -432,12 +432,12 @@ class YaraIOCManager(managers.IOCManager):
         Write out yara signatures to a file.
         """
         fout = open(output_file, 'wb')
-        fout.write('\n')
+        fout.write(b'\n')
 
         for iocid in self.yara_signatures:
             signature = self.yara_signatures[iocid]
             fout.write(signature)
-            fout.write('\n')
+            fout.write(b'\n')
 
         fout.close()
         return True


### PR DESCRIPTION
Addressing an error encountered in python3:
```
Traceback (most recent call last):
  File "openioc_to_yara.py", line 506, in <module>
    main(opts)
  File "openioc_to_yara.py", line 486, in main
    iocm.write_yara(output_file)
  File "openioc_to_yara.py", line 435, in write_yara
    fout.write('\n')
```